### PR TITLE
Update name and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Experimental MakeCode extension to run ML4F models
+# MakeCode extension to run ML4F models
+
+This extension is a work in progress. It supports unreleased work on the micro:bit machine learning tool.
 
 [![MakeCode Project](https://github.com/microbit-foundation/pxt-ml-runner-poc/actions/workflows/makecode.yml/badge.svg)](https://github.com/microbit-foundation/pxt-ml-runner-poc/actions/workflows/makecode.yml)
 [![Header Generator Tests](https://github.com/microbit-foundation/pxt-ml-runner-poc/actions/workflows/header-gen.yml/badge.svg)](https://github.com/microbit-foundation/pxt-ml-runner-poc/actions/workflows/header-gen.yml)

--- a/pxt.json
+++ b/pxt.json
@@ -1,7 +1,7 @@
 {
-    "name": "ml-runner-poc",
+    "name": "Machine Learning Runner",
     "version": "0.3.9",
-    "description": "Experimental extension to run ML4F models in micro:bit MakeCode",
+    "description": "Extension to run ML4F models in micro:bit MakeCode",
     "dependencies": {
         "core": "*"
     },

--- a/pxt.json
+++ b/pxt.json
@@ -1,5 +1,5 @@
 {
-    "name": "Machine Learning Runner",
+    "name": "machine-learning-runner",
     "version": "0.3.9",
     "description": "Extension to run ML4F models in micro:bit MakeCode",
     "dependencies": {


### PR DESCRIPTION
Remove the word exerperimental from the `readme` and add the same "work in progress" paragraph as the pxt-microbit-ml extension. 

Update the name in `pxt.json` to match the same format as pxt-microbit-ml. 