### PR TITLE
Publish to the npm registry not GHP

### DIFF
--- a/.github/workflows/header-gen.yml
+++ b/.github/workflows/header-gen.yml
@@ -4,12 +4,14 @@ on:
   release:
     types: [created]
   push:
-    branches: '*'
+    branches: 
+    - "*"
     paths:
     - "header-gen/**"
     - "**/header-gen.yml"
   pull_request:
-    branches: '*'
+    branches: 
+    - "*"
     paths:
     - "header-gen/**"
     - "**/header-gen.yml"
@@ -29,7 +31,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-        registry-url: "https://npm.pkg.github.com"
+        registry-url: "https://registry.npmjs.org"
         cache: npm
         cache-dependency-path: header-gen/package-lock.json
 
@@ -56,4 +58,4 @@ jobs:
       if: github.event_name == 'release' && github.event.action == 'created'
       working-directory: ./header-gen
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/header-gen/package.json
+++ b/header-gen/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@microbit-foundation/ml-header-generator",
+  "name": "@microbit/ml-header-generator",
   "version": "0.4.0",
   "description": "A simple TS script to generate a header blob for the ML runner",
   "author": "Micro:bit Educational Foundation <package-help@microbit.org>",


### PR DESCRIPTION
This will enable easy consumption from the open source ML tool app.

I'll release a 0.4.1 after this is merged. There are no other recent changes so it'll be just the header generator and a pointless version of the extension (not an issue, just noting).